### PR TITLE
Add admin check to user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The React app will be available at `http://localhost:5173` by default.
 The backend exposes a small set of CRUD endpoints secured with HTTP Basic auth:
 
 ```
-POST /users/                  create a new user
+POST /users/                  create a new user (admin role required)
 GET  /outlets/                list outlets
 POST /outlets/                create outlet
 GET  /periods/                list reporting periods

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,13 @@ def get_current_user(credentials: HTTPBasicCredentials = Depends(security), db: 
     return user
 
 @app.post("/users/", response_model=schemas.User)
-def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+def create_user(
+    user: schemas.UserCreate,
+    db: Session = Depends(get_db),
+    current: models.User = Depends(get_current_user),
+):
+    if current.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
     hashed_pw = bcrypt.hash(user.password)
     db_user = models.User(username=user.username, password=hashed_pw, role=user.role)
     db.add(db_user)


### PR DESCRIPTION
## Summary
- require authentication for POST `/users/`
- only allow admins to create new users
- document the admin requirement in API section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686378af71a083298c6a29f90c21eda8