### PR TITLE
Add Node.js version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This will start the FastAPI server at `http://localhost:8000`.
 
 ## Frontend development
 
+This project requires **Node.js 18** or newer.
+
 Install Node dependencies:
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- require Node 18 in `frontend/package.json`
- document the Node version in the frontend setup section

## Testing
- `npm run lint`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68637a23ac2c8329a0a0709b2034b01c