### PR TITLE
Fix missing FastAPI imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 # Node
 frontend/node_modules/
 frontend/dist/
+*.db

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 
+from fastapi import FastAPI, Depends, HTTPException, BackgroundTasks
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from .database import SessionLocal, engine, Base
 from . import models, schemas
 from passlib.hash import bcrypt

--- a/poetry.lock
+++ b/poetry.lock
@@ -1713,5 +1713,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12"
-content-hash = "89bb7194ba9d9a7a2f7dd7bab1b53d2cc8a7e4614678d6a6c96326c622ac00f3"
+python-versions = "^3.12"
+content-hash = "d0c8d859cee141074b4f004241c55551d2e55bb7991efd53cdf30a98b1893048"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,22 @@
-[project]
+[tool.poetry]
 name = "360-performance-hub"
 version = "0.1.0"
 description = ""
-authors = [
-    {name = "Codex",email = "codex@openai.com"}
-]
+authors = ["Codex <codex@openai.com>"]
 readme = "README.md"
-requires-python = ">=3.12"
-dependencies = [
-    "fastapi (>=0.115.14,<0.116.0)",
-    "uvicorn[standard] (>=0.35.0,<0.36.0)",
-    "sqlalchemy (>=2.0.41,<3.0.0)",
-    "psycopg2-binary (>=2.9.10,<3.0.0)",
-    "python-multipart (>=0.0.20,<0.0.21)",
-    "python-dotenv (>=1.1.1,<2.0.0)",
-    "passlib[bcrypt] (>=1.7.4,<2.0.0)",
-    "python-pptx (>=1.0.2,<2.0.0)",
-    "matplotlib (>=3.10.3,<4.0.0)"
-]
+packages = [{include = "app"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = ">=0.115.14,<0.116.0"
+uvicorn = {version = ">=0.35.0,<0.36.0", extras = ["standard"]}
+sqlalchemy = ">=2.0.41,<3.0.0"
+psycopg2-binary = ">=2.9.10,<3.0.0"
+python-multipart = ">=0.0.20,<0.0.21"
+python-dotenv = ">=1.1.1,<2.0.0"
+passlib = {version = ">=1.7.4,<2.0.0", extras = ["bcrypt"]}
+python-pptx = ">=1.0.2,<2.0.0"
+matplotlib = ">=3.10.3,<4.0.0"
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add missing FastAPI and IntegrityError imports
- convert to `[tool.poetry]` and declare packages
- ignore db files

## Testing
- `poetry lock`
- `poetry install`
- `pytest -q`
- `poetry run uvicorn app.main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_68637c2cfd8c83298726f9affb4c4d62