### PR TITLE
Fix missing FastAPI imports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 
+from fastapi import FastAPI, Depends, HTTPException, BackgroundTasks
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from .database import SessionLocal, engine, Base
 from . import models, schemas
 from passlib.hash import bcrypt


### PR DESCRIPTION
## Summary
- restore FastAPI imports in `app/main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863821616288329a2c22c63f6b6babc