### PR TITLE
Update Node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This will start the FastAPI server at `http://localhost:8000`.
 
 ## Frontend development
 
-This project requires **Node.js 18** or newer.
+This project requires **Node.js 20** or newer.
 
 Install Node dependencies:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- require Node 20 or newer to run the frontend

## Testing
- `npm show vite version`

------
https://chatgpt.com/codex/tasks/task_e_686384475cb48329afcabea81fe5fca7