### PR TITLE
Fix container startup by installing gunicorn

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -377,6 +377,28 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "gunicorn"
+version = "23.0.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"},
+    {file = "gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -1714,4 +1736,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "d0c8d859cee141074b4f004241c55551d2e55bb7991efd53cdf30a98b1893048"
+content-hash = "f8073f2d32c8795325f5c33eb0b50acfd396946af15edcb0e8b74d506274aed8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python-dotenv = ">=1.1.1,<2.0.0"
 passlib = {version = ">=1.7.4,<2.0.0", extras = ["bcrypt"]}
 python-pptx = ">=1.0.2,<2.0.0"
 matplotlib = ">=3.10.3,<4.0.0"
+gunicorn = ">=23.0,<24.0"
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- install gunicorn so `CMD ["gunicorn" ...]` works in Docker

## Testing
- `pytest -q`
- `poetry run python -m py_compile $(git ls-files '*.py')`
- ❌ `docker compose build app` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686387eed3f083298ba18b1bba207fdb