### PR TITLE
Update nginx host port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,5 +120,5 @@ docker compose run --rm certbot
 docker compose up -d db app nginx
 ```
 
-Nginx will forward traffic to the FastAPI app on port 80/443 using the certificates
+Nginx will forward traffic to the FastAPI app on port 8080/443 using the certificates
 managed by Certbot. Edit `nginx/default.conf` to set your real domain.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - certbot-etc:/etc/letsencrypt
       - certbot-www:/var/www/certbot
     ports:
-      - "80:80"
+      - "8080:80"
       - "443:443"
     depends_on:
       - app


### PR DESCRIPTION
## Summary
- expose nginx on host port 8080 instead of port 80 to avoid conflicts
- mention new port mapping in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638a3199208329a5189b4da860010b